### PR TITLE
[JENKINS-30744] Updated to use Branch.encodedName

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <version>0.2-beta-3</version>
+      <version>0.2-beta-7-SNAPSHOT</version>
     </dependency>
 
     <!-- Only used for FakeHttpServletRequest to fake out Stapler -->

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,12 @@
       <artifactId>git</artifactId>
       <version>2.3-beta-2</version>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>scm-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/google/jenkins/plugins/dsl/YamlMultiBranchProject.java
+++ b/src/main/java/com/google/jenkins/plugins/dsl/YamlMultiBranchProject.java
@@ -16,7 +16,6 @@
 package com.google.jenkins.plugins.dsl;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -49,7 +48,6 @@ import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 
 import jenkins.branch.BranchProjectFactory;
-import jenkins.branch.DefaultDeadBranchStrategy;
 import jenkins.branch.MultiBranchProject;
 import jenkins.branch.MultiBranchProjectDescriptor;
 import jenkins.model.Jenkins;
@@ -71,38 +69,6 @@ public class YamlMultiBranchProject<T extends AbstractProject & TopLevelItem>
    */
   public YamlMultiBranchProject(ItemGroup parent, String name) {
     super(parent, name);
-
-    // By default, clean up branches that have been deleted.
-    DefaultDeadBranchStrategy deadBranchStrategy =
-        new DefaultDeadBranchStrategy(
-            true /* prune dead branches */,
-            "0" /* days to keep */,
-            "0" /* num to keep */);
-
-    // Monkey patch the better default.
-    // TODO(mattmoor): upstream making the "deadBranchStrategy"
-    // field protected instead of patching the object to set it here.
-    {
-      Class<?> clazz = YamlMultiBranchProject.class.getSuperclass();
-      Field field = null;
-      for (Field iter : clazz.getDeclaredFields()) {
-        if ("deadBranchStrategy".equals(iter.getName())) {
-          field = iter;
-          break;
-        }
-      }
-      if (field == null) {
-        throw new IllegalStateException(
-            "deadBranchStrategy field missing from MultiBranchProject");
-      }
-      try {
-        field.setAccessible(true);
-        field.set(this, deadBranchStrategy);
-      } catch (IllegalAccessException e) {
-        // Impossible, we have given ourselves access.
-      }
-    }
-    deadBranchStrategy.setOwner(this);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/google/jenkins/plugins/dsl/YamlProjectFactory.java
+++ b/src/main/java/com/google/jenkins/plugins/dsl/YamlProjectFactory.java
@@ -27,9 +27,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Charsets;
-import com.google.common.hash.Hashing;
-import com.google.common.primitives.UnsignedLongs;
 import com.google.jenkins.plugins.dsl.restrict.AbstractRestriction;
 
 import hudson.Extension;
@@ -91,23 +88,13 @@ public class YamlProjectFactory<T extends AbstractProject & TopLevelItem>
   @Override
   public YamlProject<T> newInstance(final Branch branch) {
     try {
-      // If the branch name contains '/' then use its MD5 hash
-      // as the project name, but otherwise use the branch name
-      // for backwards compatibility.
-      final String hashedName = UnsignedLongs.toString(Hashing.md5().hashString(
-          branch.getName(), Charsets.UTF_8).asLong(), 16);
-      final String projectName =
-          branch.getName().indexOf('/') == -1 ? branch.getName() : hashedName;
       final YamlProject<T> project = new YamlProject<T>(
           (YamlMultiBranchProject<T>) getOwner(),
-          projectName, null /* module */);
-
-      // Set the display name so that it is always the branch name.
-      project.setDisplayName(branch.getName());
+          branch.getEncodedName(), null /* module */);
 
       project.setBranch(branch);
 
-      return decorate(project);
+      return project;
     } catch (IOException e) {
       logger.log(SEVERE, e.getMessage(), e);
       return null;

--- a/src/test/java/com/google/jenkins/plugins/dsl/YamlProjectFactoryTest.java
+++ b/src/test/java/com/google/jenkins/plugins/dsl/YamlProjectFactoryTest.java
@@ -205,6 +205,7 @@ public class YamlProjectFactoryTest {
 
     YamlProject project = underTest.newInstance(branch);
     assertNotNull(project);
+    underTest.decorate(project);
     assertEquals(YAML_PATH, project.getYamlPath());
     assertSame(RESTRICTION, project.getRestriction());
     assertSame(branch, project.getBranch());


### PR DESCRIPTION
Downstream off https://github.com/jenkinsci/branch-api-plugin/pull/18. Subsumes #8, so consider [incremental diff](https://github.com/jglick/yaml-project-plugin/compare/OrphanedItemStrategy...jglick:slashy-branches-JENKINS-30744). Untested.

@reviewbybees esp. @stephenc
