### PR TITLE
Replace deprecated FreeStyleProject.DESCRIPTOR, fix test on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ work/
 */.gitignore
 *.iml
 */*.iml
+.idea/
 dependency-reduced-pom.xml

--- a/src/test/java/com/google/jenkins/plugins/delegate/AbstractBranchAwareProjectTest.java
+++ b/src/test/java/com/google/jenkins/plugins/delegate/AbstractBranchAwareProjectTest.java
@@ -81,10 +81,10 @@ public class AbstractBranchAwareProjectTest {
   @Test
   public void testSimple() throws Exception {
     TestBranchAwareProject topLevelProject =
-        Jenkins.getInstance().createProject(
+            Jenkins.getInstance().createProject(
             TestBranchAwareProject.class, "topLevelProject");
 
-    FreeStyleProject leafProject = FreeStyleProject.DESCRIPTOR.newInstance(
+    FreeStyleProject leafProject = Jenkins.getInstance().getDescriptorByType(FreeStyleProject.DescriptorImpl.class).newInstance(
         topLevelProject, "foo");
     leafProject.setScm(new DelegateSCM(TestBranchAwareProject.class));
     topLevelProject.setItem(leafProject);
@@ -116,8 +116,9 @@ public class AbstractBranchAwareProjectTest {
     topLevelProject.setItem(middleProject);
     middleProject.onCreatedFromScratch();
 
-    FreeStyleProject leafProject = FreeStyleProject.DESCRIPTOR.newInstance(
-        middleProject, "foo");
+    FreeStyleProject leafProject = Jenkins.getInstance()
+            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class).newInstance(
+                    middleProject, "foo");
     leafProject.setScm(new DelegateSCM(TestBranchAwareProject.class));
     middleProject.setItem(leafProject);
     leafProject.onCreatedFromScratch();
@@ -171,8 +172,8 @@ public class AbstractBranchAwareProjectTest {
         Jenkins.getInstance().createProject(
             TestBranchAwareProject.class, "topLevelProject");
 
-    FreeStyleProject leafProject = FreeStyleProject.DESCRIPTOR.newInstance(
-        topLevelProject, "foo");
+    FreeStyleProject leafProject = Jenkins.getInstance()
+            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class).newInstance(topLevelProject, "foo");
     leafProject.setScm(new DelegateSCM(TestBranchAwareProject.class));
     topLevelProject.setItem(leafProject);
     leafProject.onCreatedFromScratch();
@@ -198,8 +199,8 @@ public class AbstractBranchAwareProjectTest {
     // and the grep for WORLD to fail.
     // topLevelProject.setScm(new SemiNullSCM());
 
-    FreeStyleProject leafProject = FreeStyleProject.DESCRIPTOR.newInstance(
-        topLevelProject, "foo");
+    FreeStyleProject leafProject = Jenkins.getInstance()
+            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class).newInstance(topLevelProject, "foo");
     leafProject.setScm(new DelegateSCM(TestBranchAwareProject.class));
     topLevelProject.setItem(leafProject);
     leafProject.onCreatedFromScratch();
@@ -229,8 +230,8 @@ public class AbstractBranchAwareProjectTest {
             TestBranchAwareProject.class, "topLevelProject");
     topLevelProject.setScm(new SemiNullSCM());
 
-    FreeStyleProject leafProject = FreeStyleProject.DESCRIPTOR.newInstance(
-        topLevelProject, "foo");
+    FreeStyleProject leafProject = Jenkins.getInstance()
+            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class).newInstance(topLevelProject, "foo");
     leafProject.setScm(new DelegateSCM(TestBranchAwareProject.class));
     topLevelProject.setItem(leafProject);
     leafProject.onCreatedFromScratch();

--- a/src/test/java/com/google/jenkins/plugins/delegate/AbstractBranchAwareProjectTest.java
+++ b/src/test/java/com/google/jenkins/plugins/delegate/AbstractBranchAwareProjectTest.java
@@ -84,8 +84,9 @@ public class AbstractBranchAwareProjectTest {
             Jenkins.getInstance().createProject(
             TestBranchAwareProject.class, "topLevelProject");
 
-    FreeStyleProject leafProject = Jenkins.getInstance().getDescriptorByType(FreeStyleProject.DescriptorImpl.class).newInstance(
-        topLevelProject, "foo");
+    FreeStyleProject leafProject = Jenkins.getInstance()
+            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class)
+            .newInstance(topLevelProject, "foo");
     leafProject.setScm(new DelegateSCM(TestBranchAwareProject.class));
     topLevelProject.setItem(leafProject);
     leafProject.onCreatedFromScratch();
@@ -117,8 +118,8 @@ public class AbstractBranchAwareProjectTest {
     middleProject.onCreatedFromScratch();
 
     FreeStyleProject leafProject = Jenkins.getInstance()
-            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class).newInstance(
-                    middleProject, "foo");
+            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class)
+            .newInstance(middleProject, "foo");
     leafProject.setScm(new DelegateSCM(TestBranchAwareProject.class));
     middleProject.setItem(leafProject);
     leafProject.onCreatedFromScratch();
@@ -173,7 +174,8 @@ public class AbstractBranchAwareProjectTest {
             TestBranchAwareProject.class, "topLevelProject");
 
     FreeStyleProject leafProject = Jenkins.getInstance()
-            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class).newInstance(topLevelProject, "foo");
+            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class)
+            .newInstance(topLevelProject, "foo");
     leafProject.setScm(new DelegateSCM(TestBranchAwareProject.class));
     topLevelProject.setItem(leafProject);
     leafProject.onCreatedFromScratch();
@@ -200,7 +202,8 @@ public class AbstractBranchAwareProjectTest {
     // topLevelProject.setScm(new SemiNullSCM());
 
     FreeStyleProject leafProject = Jenkins.getInstance()
-            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class).newInstance(topLevelProject, "foo");
+            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class)
+            .newInstance(topLevelProject, "foo");
     leafProject.setScm(new DelegateSCM(TestBranchAwareProject.class));
     topLevelProject.setItem(leafProject);
     leafProject.onCreatedFromScratch();
@@ -231,7 +234,8 @@ public class AbstractBranchAwareProjectTest {
     topLevelProject.setScm(new SemiNullSCM());
 
     FreeStyleProject leafProject = Jenkins.getInstance()
-            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class).newInstance(topLevelProject, "foo");
+            .getDescriptorByType(FreeStyleProject.DescriptorImpl.class)
+            .newInstance(topLevelProject, "foo");
     leafProject.setScm(new DelegateSCM(TestBranchAwareProject.class));
     topLevelProject.setItem(leafProject);
     leafProject.onCreatedFromScratch();

--- a/src/test/java/com/google/jenkins/plugins/dsl/YamlProjectTest.java
+++ b/src/test/java/com/google/jenkins/plugins/dsl/YamlProjectTest.java
@@ -41,6 +41,8 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -567,7 +569,7 @@ public class YamlProjectTest<T extends AbstractProject & TopLevelItem> {
   @Test
   public void testRestrictionFailure_trampolineJob() throws Exception {
     String body = readResource("trampoline.yaml");
-    body = body.replaceAll(".inner.yaml", innerFile.toString());
+    body = body.replaceAll(".inner.yaml", StringUtils.escape(innerFile.toString()));
     writeStringToFile(body, yamlFile);
     writeResourceToFile("bad.yaml", innerFile);
     underTest.setRestriction(new CustomBlacklist(

--- a/src/test/java/com/google/jenkins/plugins/dsl/YamlProjectTest.java
+++ b/src/test/java/com/google/jenkins/plugins/dsl/YamlProjectTest.java
@@ -41,7 +41,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -569,7 +568,8 @@ public class YamlProjectTest<T extends AbstractProject & TopLevelItem> {
   @Test
   public void testRestrictionFailure_trampolineJob() throws Exception {
     String body = readResource("trampoline.yaml");
-    body = body.replaceAll(".inner.yaml", StringUtils.escape(innerFile.toString()));
+    body = body.replaceAll(".inner.yaml",
+            StringUtils.escape(innerFile.toString()));
     writeStringToFile(body, yamlFile);
     writeResourceToFile("bad.yaml", innerFile);
     underTest.setRestriction(new CustomBlacklist(


### PR DESCRIPTION
FreeStyleProject.DESCRIPTOR is deprecated, so moved to the correct way of getting the descriptor. Also, fixed a test that was failing on Windows because of a path issue (\ not being escaped correctly).